### PR TITLE
Added cookbook option to template resource

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -83,6 +83,7 @@ action :install do
 
     template "#{install_dir}/bin/nexus.rc" do
       source 'nexus.rc.erb'
+      cookbook 'nexus3'
       variables(user: usr)
       mode '0644'
       owner usr
@@ -119,6 +120,7 @@ action :install do
     when 'systemd'
       template "/etc/systemd/system/#{new_resource.servicename}.service" do
         source 'systemd.erb'
+        cookbook 'nexus3'
         mode '0755'
         variables(user: usr, home: new_resource.home)
         notifies(:restart, "service[#{new_resource.servicename}]")


### PR DESCRIPTION
@dhoer,

We'd like to leverage this resource you wrote for installing Nexus 3 however, this change is required for us to do so.  The behavior without specifying the cookbook option results in a FileNotFoundException due to Chef searching for template files in our wrapper cookbook.

Thanks!