### PR TITLE
Fixed version regex that matches host-name when containing digits

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -28,7 +28,7 @@ def filename(download_url)
 end
 
 def version(download_url)
-  /(?<=nexus-)(\d\.\d+.\d-.\d)|(?<=nexus-)(\d+.\d-.\d)/.match(download_url).to_s # http://rubular.com/r/xutlWB31fR
+  /(?<=nexus-)(\d\.\d+.\d-.\d)|(?<=nexus-)(\d+.\d-.\d)/.match(download_url).to_s # http://rubular.com/r/kS3DK4zmQb
 end
 
 def usr

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -28,7 +28,7 @@ def filename(download_url)
 end
 
 def version(download_url)
-  /\d\.\d+.\d-.\d|\d+.\d-.\d/.match(download_url).to_s # http://rubular.com/r/xutlWB31fR
+  /(?<=nexus-)(\d\.\d+.\d-.\d)|(?<=nexus-)(\d+.\d-.\d)/.match(download_url).to_s # http://rubular.com/r/xutlWB31fR
 end
 
 def usr


### PR DESCRIPTION
i.e.

`http://vm-010-078.admin.my.domain/downloads/nexus/3/nexus-2.13.1-01-unix.tar.gz`

the previous regex also matched `010-078`.